### PR TITLE
Update readme and add Budgie Ubuntu flavour

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Snapshots allow you to rollback your system to a previous state if there is a pr
 Supports:
 - Ubuntu 21.04 or later.
 - Root filesystem on ZFS.
-- Choose from: Ubuntu Server, Ubuntu Desktop, Kubuntu, Xubuntu, and Ubuntu MATE.
+- Choose from: Ubuntu Server, Ubuntu Desktop, Kubuntu, Xubuntu, Budgie, and Ubuntu MATE.
 - Single, mirror, raidz1, raidz2, and raidz3 topologies.
 - Native ZFS encryption.
 - Remote unlocking of encrypted pools at boot over SSH.
@@ -18,7 +18,7 @@ Supports:
 ## Usage
 Boot the system with an Ubuntu live desktop iso (ZFS 2.0 support needed for native encryption, so use Ubuntu 21.04 or later). Start the terminal (Ctrl+Alt+T) and enter the following.
 
-	git clone https://gitlab.com/Sithuk/ubuntu-server-zfsbootmenu.git ~/ubuntu-server-zfsbootmenu
+	git clone https://github.com/Sithuk/ubuntu-server-zfsbootmenu.git ~/ubuntu-server-zfsbootmenu
     cd ~/ubuntu-server-zfsbootmenu
     chmod +x ubuntu_server_encrypted_root_zfs.sh
 	

--- a/ubuntu_server_encrypted_root_zfs.sh
+++ b/ubuntu_server_encrypted_root_zfs.sh
@@ -1092,6 +1092,11 @@ distroinstall(){
 			##Select lightdm as display manager if asked during install.
 			apt install --yes xubuntu-desktop
 		;;
+		budgie)
+			##Ubuntu budgie desktop install has a full GUI environment.
+			##Select lightdm as display manager if asked during install.
+			apt install --yes ubuntu-budgie-desktop
+		;;
 		MATE)
 			##Ubuntu MATE desktop install has a full GUI environment.
 			##Select lightdm as display manager if asked during install.

--- a/ubuntu_server_encrypted_root_zfs.sh
+++ b/ubuntu_server_encrypted_root_zfs.sh
@@ -41,7 +41,7 @@ set -euo pipefail
 
 ##Variables:
 ubuntuver="jammy" #Ubuntu release to install. "hirsute" (21.04). "impish" (21.10). "jammy" (22.04).
-distro_variant="server" #Ubuntu variant to install. "server" (Ubuntu server; cli only.) "desktop" (Default Ubuntu desktop install). "kubuntu" (KDE plasma desktop variant). "xubuntu" (Xfce desktop variant). "MATE" (MATE desktop variant).
+distro_variant="server" #Ubuntu variant to install. "server" (Ubuntu server; cli only.) "desktop" (Default Ubuntu desktop install). "kubuntu" (KDE plasma desktop variant). "xubuntu" (Xfce desktop variant). "budgie" (Budgie desktop variant). "MATE" (MATE desktop variant).
 user="testuser" #Username for new install.
 PASSWORD="testuser" #Password for user in new install.
 hostname="ubuntu" #Name to identify the main system on the network. An underscore is DNS non-compliant.


### PR DESCRIPTION
By the way, on my hardware I was dropped into an EFI shell.
I had to manually run fs1: and cd efi/refind and run refind_x64.efi to boot into refind and then zfsbootmenu.
To fix this I ran `sudo mvrefind /boot/efi/EFI/refind /boot/efi/EFI/BOOT` when booted into Ubuntu.