### PR TITLE
Fixes Pool topology not recognised error on raidz1 raidz2 and raidz3

### DIFF
--- a/ubuntu_server_encrypted_root_zfs.sh
+++ b/ubuntu_server_encrypted_root_zfs.sh
@@ -252,7 +252,7 @@ getdiskID_pool(){
 			getdiskID "$pool" "1" "1"
 		;;
 
-		mirror|raid0|raidz)
+		mirror|raid0|raidz*)
 			echo "The $pool pool disk topology is $topology_pool_pointer with $disks_pointer disks."
 			diskidnum="1"
 			while [ "$diskidnum" -le "$disks_pointer" ];


### PR DESCRIPTION
Fixes bug that triggers "Pool topology not recognised. Check pool topology variable." error when type raidz1, raidz2 or raidz3 is used.