### PR TITLE
Add partprobe or newly created partitions won't be recognized

### DIFF
--- a/ubuntu_server_encrypted_root_zfs.sh
+++ b/ubuntu_server_encrypted_root_zfs.sh
@@ -468,6 +468,7 @@ debootstrap_part1_Func(){
 			sgdisk     -n3:0:0      -t3:BF00 /dev/disk/by-id/"${diskidnum}"
 		
 		done < /tmp/diskid_check_"${pool}".txt
+		partprobe
 		sleep 2
 	}
 	partitionsFunc

--- a/ubuntu_server_encrypted_root_zfs.sh
+++ b/ubuntu_server_encrypted_root_zfs.sh
@@ -955,7 +955,7 @@ systemsetupFunc_part3(){
 		fi
 
 		echo "Creating FAT32 filesystem in EFI partition of disk ${diskidnum}. ESP mountpoint is ${esp_mount}"
-		umount /dev/disk/by-id/"${diskidnum}"-part1
+		umount -q /dev/disk/by-id/"${diskidnum}"-part1 || true
 		mkdosfs -F 32 -s 1 -n EFI /dev/disk/by-id/"${diskidnum}"-part1
 		sleep 2
 		blkid_part1=""

--- a/ubuntu_server_encrypted_root_zfs.sh
+++ b/ubuntu_server_encrypted_root_zfs.sh
@@ -955,6 +955,7 @@ systemsetupFunc_part3(){
 		fi
 
 		echo "Creating FAT32 filesystem in EFI partition of disk ${diskidnum}. ESP mountpoint is ${esp_mount}"
+		umount /dev/disk/by-id/"${diskidnum}"-part1
 		mkdosfs -F 32 -s 1 -n EFI /dev/disk/by-id/"${diskidnum}"-part1
 		sleep 2
 		blkid_part1=""


### PR DESCRIPTION
This causes an error in my install because one of the newly created partitions wasn't found.